### PR TITLE
Add `pip install -U` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Vagrant provisioning scripts.
 
   ``` bash
   cd /var/www/courtlistener
+  pip install -U requirements.txt
   ./manage.py migrate
   ./manage.py syncdb #to create the admin user
   ```


### PR DESCRIPTION
The instructions for running the Vagrant machine as written lead to an outdated dependency being installed, which leaves the local CourtListener instance broken. I'm not sure how to do it the "right" way with Ansible, so I just added an instruction to the README file to upgrade the dependencies of the program.