### PR TITLE
Revisions based on install-to-search test

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ NOTE:  If you encounter solr errors when adding data, see freelawmachine issue #
 
 ## Modifying your local CourtListener website and contributing back to its repository
 
-You should now have a working local instance of the CourtListener website.  You should also have a copy of the CourtListener repository as a sub-folder.  To modify it and contribute your changes back to its repository, follow the [GitHub Flow](https://guides.github.com/introduction/flow/).  *(Fork [CourtListener](https://github.com/freelawproject/courtlistener).  In your repo, create a branch.  Clone to your local CL folder.  Select the branch.  Modify CL.  Commit and push up your GitHub repo.  Submit pull request to your master branch.  Accept while squashing your commits.  Submit pull request back to main CL repository.  Changes that do not align with the Free Law Project's direction may not be accepted, but you can always continue developing within your fork.)*
+You should now have a working local instance of the CourtListener website.  You should also have a copy of the CourtListener repository as a sub-folder.  To modify it and contribute your changes back to its repository, follow the [GitHub Flow](https://guides.github.com/introduction/flow/).
 
 ## Working with and contributing to the FreeLawMachine repository
 

--- a/README.md
+++ b/README.md
@@ -1,74 +1,28 @@
 Free Law (Virtual) Machine v2.1.0
 ==================================
 
-This project is designed to provide automation around building a ready-to-run
-development environment for the [Free Law Project](https://github.com/freelawproject) using Vagrant boxes.
+Want to help develop Free Law Project functionality?
 
-Hopefully, it will do away with the manual process described
-[here](https://github.com/freelawproject/courtlistener/wiki/Installing-CourtListener-on-Ubuntu-Linux)
-and make having a dev environment as easy as `vagrant up`.
+Use this repository and the steps below to build your own virtual machine and ready-to-run development environment for the [Free Law Project](https://github.com/freelawproject), and the [CourtListener repository](https://github.com/freelawprojectcourtlistener) and website app in particular.  You will also be able to build new or custom Vagrant boxes and contribute back to this freelawmachine repository.
 
-## Requirements
-* [Vagrant 1.8.5](https://www.vagrantup.com)
-* [Virtualbox 5.1.4](https://www.virtualbox.org/)
-* (Optional) [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-* (Optional) [Packer 0.10.1](https://packer.io/downloads.html)
+This repository and the steps supercede the manual process [described](https://github.com/freelawproject/courtlistener/wiki/Installing-CourtListener-on-Ubuntu-Linux) in the CourtListener [wiki](https://github.com/freelawproject/courtlistener/wiki).  They are intended to make the creation of a dev environment about as easy as a `vagrant up` command.
 
-And a high-speed network connection since the VM will need to pull down
-packages! (You are installing Ubuntu...so do this via a cellular data
-connection at your own $$ peril!)
+## Step 1:  Install prerequisites
 
-## Changes in 2.1.0
-* Fixed issues related to Solr core creation/destruction during Django tests
-* Added new box version! The new *freelawproject/freelawbox64-desktop* base box
-  provides an X11/XFCE4 desktop environment with Chromium installed and ready
-  for Selenium tests
+Install the following.  Use a high-speed connection.  (These components are large, so avoid connections for which you will have to pay $$ for the sizes of your downloads!)
 
-## Changes in 2.0.2
-* Fix for missing `/reloadCache` Solr endpoint
+* [Vagrant 1.8.5 or greater](https://www.vagrantup.com)
+* [Virtualbox 5.1.4 or greater](https://www.virtualbox.org/)
+* (Optional) [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) OR [GitHub Desktop](https://desktop.github.com)
+* (Optional) [Packer 0.10.1](https://packer.io/downloads.html) (if you want to contribute to this freelawmachine repository)
 
-## New in Version 2.0.0!
+## Step 2:  Install CourtListener
 
-Major changes for users of 1.6:
-* _A wild Ansible appears!_ Provisioning is now done via Ansible playbooks
-  instead of nasty hard to maintain shell scripts.
-* The box is set up closer to the original wiki specs, so it uses a Python
-  Virtual Environment, but it should be auto-activated for you upon ssh login.
-* Similar to v1.6, _you only need the Vagrantfile_ to run the box (assuming you
-  have virtualbox and vagrant). It will do the rest.
-* *Deprecation Warning!* We're removed support for 32-bit boxes. New standard is
-  to use 64-bit to mimic exact same packages as used in Production.
+1. Make sure you have the base requirements of *Vagrant* and *VirtualBox* installed and up to date.
 
-Major changes for users of 1.5 and earlier:
-* The `flp` directory is no longer used or needed. If you want to pre-clone a
-copy of CourtListener, simply clone it to the directory where the Vagrantfile
-resides. _This is not required as the box should do that for you at startup._
-* VirtualBox is now told to allocate *2 GB* of memory to the box. This should be
-enough for dev use of CourtListener and small enough not to impact most hosts.
+2. Either download a copy of the [Vagrantfile](Vagrantfile) file into a local directory or, if you want to contribute back to this freelawmachine repository, fork it within GitHub to your GitHub account, create a branch, and use git or GitHub Desktop to clone that branch to a local directory.
 
-# Using the Free Law Machine
-
-There are two ways to use this project:
-
-1. *Running CourtListener* - this is the most common Vagrant task
-and is what brings your local Free Law development environment online and ready
-for use in development or testing CourtListener.
-
-2. *Building new or custom Vagrant Boxes (Optional)* - if you want to customize
-how the box is built or you want to contribute to this project.
-
-
-# Running CourtListener
-
-1. Make sure you have the base requirements of *Vagrant* and *VirtualBox*
-installed and up to date.
-
-2. Either clone this project using git or download a copy of the
-[Vagrantfile](Vagrantfile). Copy to a wherever you want to have CourtListener
-available.
-
-3. Open a terminal or command line and change to the directory with the
-Vagrantfile.
+3. Open a terminal or command line and change to that directory (which now contains the 'Vagrantfile' file).
 
   `cd <directory>`
 
@@ -76,34 +30,43 @@ Vagrantfile.
 
   `vagrant up`
 
-  And the base box will be pulled down from it's hosted location, installed
-  into VirtualBox, started, and last-mile provisioning steps will take place.
-  _This now includes cloning the latest copy of CourtListener for you!_
+   And the base box will be pulled down from it's hosted location, installed into VirtualBox, started, and last-mile provisioning steps will take place.  _This now includes cloning the latest copy of CourtListener for you!_
 
 5. Now to log into the box...it's a simple:
 
   `vagrant ssh`
 
-6. If you haven't used the machine yet, you'll need to do some basic
-CourtListener provisioning steps that currently aren't handled (yet) by our
-Vagrant provisioning scripts.
+  For the password, enter 'vagrant'.
+
+6. If you haven't used the machine yet, you'll need to do some basic CourtListener provisioning steps that currently aren't handled (yet) by our Vagrant provisioning scripts.  Run the following commands in the terminal:
 
   ``` bash
   cd /var/www/courtlistener
-  pip install -U requirements.txt
+  pip install -U -r requirements.txt
   ./manage.py migrate
   ./manage.py syncdb #to create the admin user
+  ./manage.py changepassword admin  #to set the password for the Django admin user
   ```
 
-#  Recommended Next Steps
-Here are a couple additional steps to get you started if you're unfamiliar with
-CourtListener or your way around a Django app.
+7. Run the following commands in the terminal to get the latest recap schema file information for solr:
 
-## Starting CourtListener
-From within the `/var/www/courtlistener` directory, simply use Django's manage
-scripts to launch the app. Make sure you pay close attention to adding the IP
-address and port number so it plays nice with Vagrant's NAT networking and the
-box's network adapters.
+``` bash
+cd /opt/solr-cores/recap/conf
+sudo service solr stop
+curl https://raw.githubusercontent.com/freelawproject/courtlistener/master/Solr/conf/recap_schema.xml --Output schema.xml
+sudo service solr start
+```
+
+8. Other commands that may be useful within the `/var/www/courtlistener` directory:
+
+``` bash
+./manage.py shell  #Opens a python shell with django stuff nicely imported.
+./manage.py dbshell  #Opens a postgres shell, handling password stuff for you.
+```
+
+##  Step 3:  Start CourtListener
+
+From within the `/var/www/courtlistener` directory, simply use the [Django](https://www.djangoproject.com/)'s manage scripts as follows to launch the app. Make sure you pay close attention to adding the IP address and port number so it plays nice with Vagrant's NAT networking and the box's network adapters.
 
 ```bash
 ./manage.py runserver 0.0.0.0:8000
@@ -112,18 +75,13 @@ box's network adapters.
 _For more details on why this is, check out this StackOverflow
 [post](http://stackoverflow.com/questions/1621457/about-ip-0-0-0-0-in-django)._
 
-Fire up your browser (on your local machine!) and confirm you've got a local
-instance that looks like [courtlistener.com](https://www.courtlistener.com/).
+Fire up your browser (on your local machine!), navigate to: [http://localhost:8000](http://localhost:8000), and confirm you've got a local instance that looks like [courtlistener.com](https://www.courtlistener.com/).
 
-  Navigate to: [http://localhost:8000](http://localhost:8000)
+You can access the administrative interface at [http://localhost:8000/admin](http://localhost:8000/admin) and with the username "admin" and the password you set above.
 
+## Step 4:  Scrape some court opinions!
 
-## Scrape Some Court Opinions!
-
-You can easily load some content into your CourtListener instance by scraping
-some courts using the [Juriscraper](https://github.com/freelawproject/juriscraper/)
-commands built into CourtListener. In either a new SSH session/shell or after
-cancelling (`ctrl-c`) the "runserver" command, try:
+You can easily load some opinions into your CourtListener instance by scraping some courts using the [Juriscraper](https://github.com/freelawproject/juriscraper/) commands built into CourtListener. In either a new SSH session/shell or after cancelling (`ctrl-c`) the "runserver" command, try:
 
 ```bash
 ./manage.py cl_scrape_opinions \
@@ -131,15 +89,11 @@ cancelling (`ctrl-c`) the "runserver" command, try:
   --rate 5
 ```
 
-CourtListener will spin up a Juriscraper instance for the given court
-and load the output into the PostgreSQL instance as well as feed the results to
-the Solr instance.
+CourtListener will spin up a Juriscraper instance for the given court and load the result items into the PostgreSQL instance as well as feed the items to the Solr instance. (If you don't get any items with "ca1", then try another like "ca6".)
 
-Once complete (after a timeout) or after you manually kill it
-with some `ctrl-c`'s, you need to tell Solr to commit changes and make the new
-docs in the index go live:
+Once complete after a successful crawl or a timeout or after you manually kill the Juriscraper instance with some `ctrl-c`'s, then you need to tell Solr to commit changes and make the new docs in the index go live:
 
-```bash
+```sh
 ./manage.py cl_update_index --do-commit --type opinions \
   --solr-url http://127.0.0.1:8983/solr/collection1
 ```
@@ -148,32 +102,45 @@ You should now have some results on the landing page as well as fully searchable
 opinions!
 
 You can inspect the Solr index cores directly using your browser:
-[http://localhost:8999/solr/#/](http://localhost:8999/solr/#/)
+[http://localhost:8983/solr/#/](http://localhost:8983/solr/#/)
 
-# Building a new Vagrant Box (For Contributors)
-Here's how to crank out a box if you've got the Requirements above. Depending
-on your network connection, CPU, disk, etc. this could take anywhere from 20
-mins to maybe 30 mins. Be patient :-)
+## Modifying your local CourtListener website and contributing back to its repository
 
-All of the tools required to build the box using [Packer](https://packer.io)
-are contained in the [packer](./packer) directory of this project. [Ansible](https://github.com/ansible/ansible) is installed into the VM image
-itself, so there's no need to have it installed on your local machine.
+You should now have a working local instance of the CourtListener website.  You should also have a copy of the CourtListener repository as a sub-folder.  To modify it and contribute your changes back to its repository, follow the [GitHub Flow](https://guides.github.com/introduction/flow/):
 
-  0. Grab the latest Free Law Machine source:
+1.  Use the [freelawproject/courtlistener](https://github.com/freelawproject/courtlistener) repository page's "fork" button to fork the repository into your own GitHub account.
+2.  [Create a branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/) for the work you want to do.
+3.  Use your computer's installation of git (or a git client, e.g. GitHub Desktop) to clone your GitHub &lt;username&gt;/courtlistener repository down into your local CourtListener folder (that was created by the vagrant/virtual-box instructions above), and then, locally, select your new branch as the active branch.
+3.  Modify your local CourtListener instance.  Use your computer's git or git client to commit your changes as often as desired to your local repository.
+4.  Periodically push your changes up to your fork and branch on GitHub.  (In essence, this backs up your local work to your storage space in your GitHub account.)
+5.  When you are done with your branch and you have tested your changes, then on GitHub submit a pull request up to your &lt;username&gt;/courtlistener repository's master branch.
+6.  On GitHub, accept that pull request within your master branch while squashing all your branch's commits into one.
+7.  Submit a pull request to the main freelawproject/courtlistener repository.
+8.  Patiently wait for your pull request to be reviewed, and patiently work with any requests for changes to what you have proposed.  Please be aware that your pull request may be rejected as a normal part of that process of reviewing and revising your proposed change.  Ultimately, please be aware that proposed changes that do not align with the Free Law Project's current vision, direction, and capabilities may not be accepted, but if this happens, you are certainly free to continue developing within your fork.
+
+## Working with and contributing to the FreeLawMachine repository
+
+### Building a new Vagrant box
+
+Here's how to crank out a box if you've got the Requirements above. Depending on your network connection, CPU, disk, etc. this could take anywhere from 20 mins to maybe 30 mins. Be patient :-)
+
+All of the tools required to build the box using [Packer](https://packer.io) are contained in the [packer](./packer) directory of this project. [Ansible](https://github.com/ansible/ansible) is installed into the VM image itself, so there's no need to have it installed on your local machine.
+
+  1. Grab the latest Free Law Machine source:
 
     `git clone https://github.com/freelawproject/freelawmachine`
 
-  1. Jump into the packer directory:
+  2. Jump into the packer directory:
 
     `cd packer`
 
-  2. Build the box! (Yes, it's that simple. Since it's configured headless, it
+  3. Build the box! (Yes, it's that simple. Since it's configured headless, it
   may appear nothing is happening for a little while. It's ok. This could take
   about 20-30 minutes!)
 
     `packer build freelawbox64.json`
 
-  3. Install the Vagrant box on your local machine. The new _.box_ file will
+  4. Install the Vagrant box on your local machine. The new _.box_ file will
   have a timestamp in the filename, so make sure to add the correct file:
 
     `vagrant box add freelawbox64-{version}.box --name freelawproject/freelawbox64`
@@ -182,7 +149,7 @@ Voila! You now have a new Vagrant box installed locally. You can even share the
 _.box_ file with others the old fashioned way, host it at a URL, etc. (Vagrant
 supports pulling boxes via URL.)
 
-# Building your own Vagrant box using the Ansible playbooks
+### Building your own Vagrant box using the Ansible playbooks
 
 If you aren't looking to build a Vagrant base box and instead just want to take
 a vanilla Ubuntu 14.04 base image (e.g. something like _ubuntu/trusty64_ or
@@ -200,8 +167,7 @@ playbooks used when building from scratch with Packer.
 
   3. Get a drink because you could be waiting about 20 minutes or so :-)
 
-
-# Vagrant Tips
+### Vagrant Tips
 If you're playing around, here are some things to remember:
 * Vagrant installs boxes typically in your home directory under something like
 `.vagrant.d`. Make sure you use the same box name when using `vagrant box add`
@@ -211,6 +177,26 @@ and it will replace that existing box. (You probably need to add `--force` or
 is and where you are running `vagrant up`. Do a simple `vagrant destroy` to
 wipe it out when you've built a new box version and want to start over.
 
+Also see [a packer template for Vagrant from Hashicorp](https://github.com/hashicorp/atlas-packer-vagrant-tutorial.git).
 
-# Some References
-[A packer template for Vagrant from Hashicorp](https://github.com/hashicorp/atlas-packer-vagrant-tutorial.git)
+## FreeLawMachine Change Log
+
+### Changes in 2.1.0
+Fixed issues related to Solr core creation/destruction during Django tests
+Added new box version! The new freelawproject/freelawbox64-desktop base box provides an X11/XFCE4 desktop environment with Chromium installed and ready for Selenium tests
+
+### Changes in 2.0.2
+Fix for missing /reloadCache Solr endpoint
+
+### New in Version 2.0.0!
+Major changes for users of 1.6:
+
+A wild Ansible appears! Provisioning is now done via Ansible playbooks instead of nasty hard to maintain shell scripts.
+The box is set up closer to the original wiki specs, so it uses a Python Virtual Environment, but it should be auto-activated for you upon ssh login.
+Similar to v1.6, you only need the Vagrantfile to run the box (assuming you have virtualbox and vagrant). It will do the rest.
+Deprecation Warning! We're removed support for 32-bit boxes. New standard is to use 64-bit to mimic exact same packages as used in Production.
+
+### Major changes for users of 1.5 and earlier:
+
+The flp directory is no longer used or needed. If you want to pre-clone a copy of CourtListener, simply clone it to the directory where the Vagrantfile resides. This is not required as the box should do that for you at startup.
+VirtualBox is now told to allocate 2 GB of memory to the box. This should be enough for dev use of CourtListener and small enough not to impact most hosts.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Free Law (Virtual) Machine v2.1.0
 
 Want to help develop Free Law Project functionality?
 
-Use this repository and the steps below to build your own virtual machine and ready-to-run development environment for the [Free Law Project](https://github.com/freelawproject), and the [CourtListener repository](https://github.com/freelawprojectcourtlistener) and website app in particular.  You will also be able to build new or custom Vagrant boxes and contribute back to this freelawmachine repository.
+Follow the steps below to build a development environment for the [Free Law Project](https://github.com/freelawproject) components like the [CourtListener repository](https://github.com/freelawprojectcourtlistener) website.  You will also be able to build new or custom Vagrant boxes and contribute back to this freelawmachine repository.
 
-This repository and the steps are an alternative to the manual process [described](https://github.com/freelawproject/courtlistener/wiki/Installing-CourtListener-on-Ubuntu-Linux) in the CourtListener [wiki](https://github.com/freelawproject/courtlistener/wiki).  They are intended to make the creation of a dev environment about as easy as a `vagrant up` command.
+This repository and the steps supercede the manual process [described](https://github.com/freelawproject/courtlistener/wiki/Installing-CourtListener-on-Ubuntu-Linux) in the CourtListener [wiki](https://github.com/freelawproject/courtlistener/wiki).  They are intended to make the creation of a dev environment about as easy as a `vagrant up` command.
 
 ## Step 1:  Install prerequisites
 
@@ -48,16 +48,7 @@ Install the following.  Use a high-speed connection.  (These components are larg
   ./manage.py changepassword admin  #to set the password for the Django admin user
   ```
 
-7. Run the following commands in the terminal to get the latest recap schema file information for solr:
-
-``` bash
-cd /opt/solr-cores/recap/conf
-sudo service solr stop
-curl https://raw.githubusercontent.com/freelawproject/courtlistener/master/Solr/conf/recap_schema.xml --Output schema.xml
-sudo service solr start
-```
-
-8. Other commands that may be useful within the `/var/www/courtlistener` directory:
+7. Other commands that may be useful within the `/var/www/courtlistener` directory:
 
 ``` bash
 ./manage.py shell  #Opens a python shell with django stuff nicely imported.
@@ -103,6 +94,8 @@ opinions!
 
 You can inspect the Solr index cores directly using your browser:
 [http://localhost:8983/solr/#/](http://localhost:8983/solr/#/)
+
+NOTE:  If you encounter solr errors when adding data, see freelawmachine issue #[28](https://github.com/freelawproject/freelawmachine/issues/28).
 
 ## Modifying your local CourtListener website and contributing back to its repository
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Want to help develop Free Law Project functionality?
 
 Use this repository and the steps below to build your own virtual machine and ready-to-run development environment for the [Free Law Project](https://github.com/freelawproject), and the [CourtListener repository](https://github.com/freelawprojectcourtlistener) and website app in particular.  You will also be able to build new or custom Vagrant boxes and contribute back to this freelawmachine repository.
 
-This repository and the steps supercede the manual process [described](https://github.com/freelawproject/courtlistener/wiki/Installing-CourtListener-on-Ubuntu-Linux) in the CourtListener [wiki](https://github.com/freelawproject/courtlistener/wiki).  They are intended to make the creation of a dev environment about as easy as a `vagrant up` command.
+This repository and the steps are an alternative to the manual process [described](https://github.com/freelawproject/courtlistener/wiki/Installing-CourtListener-on-Ubuntu-Linux) in the CourtListener [wiki](https://github.com/freelawproject/courtlistener/wiki).  They are intended to make the creation of a dev environment about as easy as a `vagrant up` command.
 
 ## Step 1:  Install prerequisites
 

--- a/README.md
+++ b/README.md
@@ -99,17 +99,7 @@ NOTE:  If you encounter solr errors when adding data, see freelawmachine issue #
 
 ## Modifying your local CourtListener website and contributing back to its repository
 
-You should now have a working local instance of the CourtListener website.  You should also have a copy of the CourtListener repository as a sub-folder.  To modify it and contribute your changes back to its repository, follow the [GitHub Flow](https://guides.github.com/introduction/flow/):
-
-1.  Use the [freelawproject/courtlistener](https://github.com/freelawproject/courtlistener) repository page's "fork" button to fork the repository into your own GitHub account.
-2.  [Create a branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/) for the work you want to do.
-3.  Use your computer's installation of git (or a git client, e.g. GitHub Desktop) to clone your GitHub &lt;username&gt;/courtlistener repository down into your local CourtListener folder (that was created by the vagrant/virtual-box instructions above), and then, locally, select your new branch as the active branch.
-3.  Modify your local CourtListener instance.  Use your computer's git or git client to commit your changes as often as desired to your local repository.
-4.  Periodically push your changes up to your fork and branch on GitHub.  (In essence, this backs up your local work to your storage space in your GitHub account.)
-5.  When you are done with your branch and you have tested your changes, then on GitHub submit a pull request up to your &lt;username&gt;/courtlistener repository's master branch.
-6.  On GitHub, accept that pull request within your master branch while squashing all your branch's commits into one.
-7.  Submit a pull request to the main freelawproject/courtlistener repository.
-8.  Patiently wait for your pull request to be reviewed, and patiently work with any requests for changes to what you have proposed.  Please be aware that your pull request may be rejected as a normal part of that process of reviewing and revising your proposed change.  Ultimately, please be aware that proposed changes that do not align with the Free Law Project's current vision, direction, and capabilities may not be accepted, but if this happens, you are certainly free to continue developing within your fork.
+You should now have a working local instance of the CourtListener website.  You should also have a copy of the CourtListener repository as a sub-folder.  To modify it and contribute your changes back to its repository, follow the [GitHub Flow](https://guides.github.com/introduction/flow/).  *(Fork [CourtListener](https://github.com/freelawproject/courtlistener).  In your repo, create a branch.  Clone to your local CL folder.  Select the branch.  Modify CL.  Commit and push up your GitHub repo.  Submit pull request to your master branch.  Accept while squashing your commits.  Submit pull request back to main CL repository.  Changes that do not align with the Free Law Project's direction may not be accepted, but you can always continue developing within your fork.)*
 
 ## Working with and contributing to the FreeLawMachine repository
 


### PR DESCRIPTION
Updated the readme.md after following and revising the instructions for setting up a local instance of the CourtListener website, populating it with data, and verifying the data can be found through the local CL search.  (Diff will not be very helpful for identifying changes due to the quantity and type.  For example, the change log section was moved to the bottom.)