### PR TITLE
docs: use 127.0.0.1 instead of loopback in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ From within the `/var/www/courtlistener` directory, simply use the [Django](http
 _For more details on why this is, check out this StackOverflow
 [post](http://stackoverflow.com/questions/1621457/about-ip-0-0-0-0-in-django)._
 
-Fire up your browser (on your local machine!), navigate to: [http://localhost:8000](http://localhost:8000), and confirm you've got a local instance that looks like [courtlistener.com](https://www.courtlistener.com/).
+Fire up your browser (on your local machine!), navigate to: [http://127.0.0.1:8000](http://127.0.0.1:8000), and confirm you've got a local instance that looks like [courtlistener.com](https://www.courtlistener.com/).
 
-You can access the administrative interface at [http://localhost:8000/admin](http://localhost:8000/admin) and with the username "admin" and the password you set above.
+You can access the administrative interface at [http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin) and with the username "admin" and the password you set above.
 
 ## Step 4:  Scrape some court opinions!
 


### PR DESCRIPTION
`cl/settings/05-private.example` has `ALLOWED_HOSTS = ['127.0.0.1']`.
Navigating to localhost results in error

```
DisallowedHost: Invalid HTTP_HOST header: 'localhost:8000'. You may need to add 'localhost' to ALLOWED_HOSTS.
```

Navigating to 127.0.0.1 works.