### PR TITLE
Small changes to ansible playbooks that allow Travis CI to use them

### DIFF
--- a/ansible/freelawmachine.yml
+++ b/ansible/freelawmachine.yml
@@ -27,7 +27,11 @@
     - vagrantbox
     - redis
     - celery
-    - postgres
+    - role: postgres
+      tags:
+        - postgres
     - solr
     - ocr
-    - courtlistener
+    - role: courtlistener
+      tags:
+        - courtlistener

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -14,8 +14,16 @@
     autoremove=yes
   with_items:
     - postgresql-9.3
-    - postgresql-contrib
+    - postgresql-contrib-9.3
     - python-psycopg2
+
+# Do this first before we change pg_hba.conf so we can guarantee we have the right password.
+- name: configure postgres super user
+  become_user: postgres
+  postgresql_user:
+    name=postgres
+    password="{{ pg_password }}"
+    login_password="{{ pg_password }}"
 
 - name: configure postgres using template file
   become_user: root
@@ -45,13 +53,6 @@
     mode=0600
 
 - include: postgres-accounts.yml
-
-#- name: configure postgres using template file
-#  become_user: root
-#  template:
-#    src=pg_hba.conf
-#    dest=/etc/postgresql/9.3/main/pg_hba.conf
-#
 
 - name: bounce postgres
   become_user: root

--- a/ansible/roles/postgres/tasks/postgres-accounts.yml
+++ b/ansible/roles/postgres/tasks/postgres-accounts.yml
@@ -1,11 +1,4 @@
 ---
-- name: configure postgres super user
-  become_user: postgres
-  postgresql_user:
-    name=postgres
-    password="{{ pg_password }}"
-    login_password="{{ pg_password }}"
-
 - name: configure django postgres user
   become_user: postgres
   postgresql_user:


### PR DESCRIPTION
Small changes to ansible playbooks that allow Travis CI to use them

Depended on by https://github.com/freelawproject/courtlistener/pull/882.

These changes are motivated by the desire to have Travis CI run
automated tests for https://github.com/freelawproject/courtlistener.
In order to do this, there are lots of dependencies that need to be
installed. Instead of reproducing the logic inside these ansible playbooks
for Travis, I'm trying to make Travis use them. In the future we can
refactor these playbooks to be more maintainable and less hacky for
both dev environments and CI/CD.

I'm not sure whether these ansible playbooks are
currently used, up to date, or even whether they currently work.
So I tried to keep changes to a minimum.

Changes

* Add tags to `postgres` and `courtlistener` roles in `freelawmachine.yml`
  so we can apply only the specific roles we need with `ansible-playbook`.
* Change `postgresql-contrib` dep to `postgresql-contrib-9.3` to ensure
  we install postgres 9.3 related packages.
* Move postgres super user configuration task ahead of changing `pg_hba.conf`
  to ensure the postgres super user has the right password.