### PR TITLE
using ansible_local on bionic box requires vagrant >= 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository and the steps supercede the manual process [described](https://g
 
 Install the following.  Use a high-speed connection.  (These components are large, so avoid connections for which you will have to pay $$ for the sizes of your downloads!)
 
-* [Vagrant 1.8.5 or greater](https://www.vagrantup.com)
+* [Vagrant 2.1.2 or greater](https://www.vagrantup.com)
 * [Virtualbox 5.1.4 or greater](https://www.virtualbox.org/)
 * (Optional) [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) OR [GitHub Desktop](https://desktop.github.com)
 * (Optional) [Packer 0.10.1](https://packer.io/downloads.html) (if you want to contribute to this freelawmachine repository)


### PR DESCRIPTION
Vagrant needs to be updated to use ansible_local on more recent ubuntu base boxes. See hashicorp/vagrant#9796.  I'm using v2.1.5 backported from sid on my stretch laptop, and the backport is easy.

An alternative, if the lower vagrant version is necessary, is to install ansible via pip as provided by vagrant config.


