### PR TITLE
use inventory option (fixes deprecation warning) ; prevent confusing …

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-hostfile = config/hosts_vagrant
+inventory = config/hosts_vagrant
 remote_user = vagrant
 private_key_file = ./.vagrant/machines/default/virtualbox/private_key
 host_key_checking = False
@@ -7,3 +7,6 @@ pipelining=True
 
 # seriously, wtf this is supposed to work with pipelining!
 allow_world_readable_tmpfiles=True
+
+[inventory]
+enable_plugins = ini


### PR DESCRIPTION
…infor message (see ansible/ansible#48859)

The ```hostfile``` option is deprecated, so using ```inventory``` instead.

The ```enable_plugins``` in the inventory section is just a workaround preventing a person using verbose from wondering "what happened?" when informed with a confusing message.